### PR TITLE
LEMSBuilder: skip components without ID

### DIFF
--- a/src/main/java/org/lemsml/jlems/core/api/LEMSBuilder.java
+++ b/src/main/java/org/lemsml/jlems/core/api/LEMSBuilder.java
@@ -95,7 +95,7 @@ public class LEMSBuilder implements ILEMSBuilder
 			for (Component cpt : lems.getComponents())
 			{
 
-				if (cpt.getID().equals(config.getSpecifiedTarget()))
+				if (cpt.getID() != null && cpt.getID().equals(config.getSpecifiedTarget()))
 				{
 					ComponentType ct = cpt.getComponentType();
 					try


### PR DESCRIPTION
When I tried to run [muscle_model](https://github.com/openworm/muscle_model/tree/master/NeuroML2) simulation in Geppetto I faced with null pointer dereference exception that I described in details [here](https://github.com/openworm/org.geppetto/issues/267#issuecomment-59546305).

This problem happens because [Figure2A.net.nml](https://github.com/openworm/muscle_model/blob/master/NeuroML2/Figure2A.net.nml#L5) contains the following lines:

``` xml
    <include href="Leak.channel.nml"/>
    <include href="k_slow.channel.nml"/>
    <include href="k_fast.channel.nml"/>
    <include href="ca_boyle.channel.nml"/>
    <include href="SingleCompMuscle.cell.nml"/>
```

which are interpreted as components without IDs. When LEMSBuilder tries to dereference one of them, the described exception is raised.

I'm not sure what kind of behaviour is preferred in this case, LEMSBuilder can either just skip empty component (as this pull request does) or it can raise a decent exception.
