### PR TITLE
Add null pointer check to avoid null pointer exception.

### DIFF
--- a/src/main/java/org/lemsml/jlems/core/run/StateInstance.java
+++ b/src/main/java/org/lemsml/jlems/core/run/StateInstance.java
@@ -300,6 +300,9 @@ public class StateInstance implements StateRunnable, ILEMSStateInstance {
 	
 
 	public void transitionTo(String rnm) throws RuntimeError {
+		if (regimeHM == null) {
+			throw new IllegalStateException("No Regimes.");
+		}
 		activeRegime = regimeHM.get(rnm);
 		activeRegime.enter();
 	}
@@ -314,6 +317,9 @@ public class StateInstance implements StateRunnable, ILEMSStateInstance {
 
 	public void initRegime() throws RuntimeError {
 		if (activeRegime == null) {
+			if (regimeHM == null || regimeHM.isEmpty()) {
+				throw new IllegalStateException("No Regimes.");
+			}
 			activeRegime = regimeHM.get(regimeHM.keySet().iterator().next());
 			// TODO just picks random regime
 		}


### PR DESCRIPTION
The code for the 'StateInstance' class is as follows. In order to ensure that 'regimeHM' is not null and non-empty when calling 'transitionTo' and 'initRefime', the 'addRegime' method must be called beforehand. 

```
public class StateInstance ... {
    	public void transitionTo(String rnm) throws RuntimeError {
		activeRegime = regimeHM.get(rnm);
		activeRegime.enter();
	}
...
	public void initRegime() throws RuntimeError {
		if (activeRegime == null) {
			activeRegime = regimeHM.get(regimeHM.keySet().iterator().next());
			// TODO just picks random regime
		}
		activeRegime.enter();
	}
...
	public void addRegime(RegimeStateInstance rsi) {
		hasRegimes = true;
		if (regimeHM == null) {
			regimeHM = new HashMap<String, RegimeStateInstance>();
		}
		regimeHM.put(rsi.getID(), rsi);
		// E.info("state instance added regime " + rsi.getID());
		if (rsi.isInitial()) {
			activeRegime = rsi;
		}

	}
}
```

However, the instance construction of StateInstance is located in the 'ownNewInstance' method of the StateType class, and it is not guaranteed that 'addRegime' will always be called. This can potentially lead to NullPointerExceptions if 'regimeHM' is not properly initialized.

```
public class StateType implements RuntimeType, ILEMSStateType {
    private StateInstance ownNewInstance() throws ContentError, ConnectionError, RuntimeError {
        ...
		if (hasRegimes) {
			for (String srn : regimeHM.keySet()) {
				ComponentRegime cr = regimeHM.get(srn);
				RegimeStateInstance rsi = cr.newInstance(uin);
				uin.addRegime(rsi); 
			}
		}
```

While NullPointerException is a type of RuntimeException, distinguishing between different types of exceptions can indeed help developers better understand the cause of the exception.
